### PR TITLE
Makefile: Use Gold, Add Graphite, OpenMP, O3, and Leak Sanitizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ include $(srctree)/scripts/Kbuild.include
 # Make variables (CC, etc...)
 
 AS		= $(CROSS_COMPILE)as
-LD		= $(CROSS_COMPILE)ld
+LD		= $(CROSS_COMPILE)ld.gold
 CC		= $(CCACHE) $(CROSS_COMPILE)gcc
 CPP		= $(CC) -E
 AR		= $(CROSS_COMPILE)ar
@@ -349,7 +349,7 @@ CHECK		= sparse
 CHECKFLAGS     := -D__linux__ -Dlinux -D__STDC__ -Dunix -D__unix__ \
 		  -Wbitwise -Wno-return-void $(CF)
 
-KERNELFLAGS	= -munaligned-access -fforce-addr -fsingle-precision-constant -mcpu=cortex-a15 -mtune=cortex-a15 -marm -mfpu=neon-vfpv4 -fgcse-las
+KERNELFLAGS	= -munaligned-access -fforce-addr -fsingle-precision-constant -mcpu=cortex-a15 -mtune=cortex-a15 -marm -mfpu=neon-vfpv4 -fgcse-las -fopenmp -fgraphite -fgraphite-identity -O3 -fsanitize=leak
 MODFLAGS	= -DMODULE $(KERNELFLAGS)
 CFLAGS_MODULE   = $(MODFLAGS)
 AFLAGS_MODULE   = $(MODFLAGS)


### PR DESCRIPTION
Just some minor changes that I used on Lollipop that improved performance, thought you may want to use them.
- The Gold linker is a linker built in to most toolchains that allows for faster linking, decreasing build time
- Graphite allows for basic polyhedral optimizations, decreasing memory usage by streamlining loops
- OpenMP is a multi-threading instruction set similar to POSIX (pthread), but allows for completing a single task across multiple threads/cores.
- Leak Sanitizer (lsan) uses libsanitizer to automatically search for and remove memory leaks.
